### PR TITLE
Change Debian Site URL

### DIFF
--- a/lib/config
+++ b/lib/config
@@ -3,7 +3,7 @@ DEBOOTSTRAP=cdebootstrap-static
 ROOTPW=password
 DISTRO=jessie
 NEWHOST=LS-Jessie
-MIRROR=http://httpredir.debian.net/debian
+MIRROR=http://deb.debian.org/debian
 FORCE_BUFFALO_KERNEL=0
 SYSTEMD=0
 


### PR DESCRIPTION
Official Annoucement
https://wiki.debian.org/DebianGeoMirror#httpredir.debian.org_.2F_http.debian.net