### PR TITLE
Properly map fan speed against gpios

### DIFF
--- a/1_debootstrap/dtb/kirkwood-linkstation-6282.dtsi
+++ b/1_debootstrap/dtb/kirkwood-linkstation-6282.dtsi
@@ -155,10 +155,10 @@
 		gpios = <&gpio0 17 GPIO_ACTIVE_LOW
 			 &gpio0 16 GPIO_ACTIVE_LOW>;
 
-		gpio-fan,speed-map = <0 3
-				1500 2
-				3250 1
-				5000 0>;
+		gpio-fan,speed-map = <0 0
+				1500 1
+				3250 2
+				5000 3>;
 
 		alarm-gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
 	};


### PR DESCRIPTION
It appears that fan speed is mapped on a reverse order. 
This also affects pwm'ing, since the logic is inverted and a pwm of 0 is `full speed` and `255` `fan off`.

As a consequence, `fancontrol` does not work either. 

I've tested this on a LS-WVL and works as expected:
```Testing pwm control hwmon1/pwm1 ...
  hwmon1/fan1_input ... speed was 5000 now 0
    It appears that fan hwmon1/fan1_input
    is controlled by pwm hwmon1/pwm1
Would you like to generate a detailed correlation (y)? 
    PWM 255 FAN 5000
    PWM 240 FAN 5000
    PWM 225 FAN 5000
    PWM 210 FAN 5000
    PWM 195 FAN 5000
    PWM 180 FAN 5000
    PWM 165 FAN 3250
    PWM 150 FAN 3250
    PWM 135 FAN 3250
    PWM 120 FAN 3250
    PWM 105 FAN 3250
    PWM 90 FAN 3250
    PWM 75 FAN 1500
    PWM 60 FAN 1500
    PWM 45 FAN 1500
    PWM 30 FAN 1500
    PWM 28 FAN 1500
    PWM 26 FAN 1500
    PWM 24 FAN 1500
    PWM 22 FAN 1500
    PWM 20 FAN 1500
    PWM 18 FAN 1500
    PWM 16 FAN 1500
    PWM 14 FAN 1500
    PWM 12 FAN 1500
    PWM 10 FAN 1500
    PWM 8 FAN 1500
    PWM 6 FAN 1500
    PWM 4 FAN 1500
    PWM 2 FAN 1500
    PWM 0 FAN 0
    Fan Stopped at PWM = 0

Testing is complete.```